### PR TITLE
feat: implement programas page 

### DIFF
--- a/src/app/programas/page.tsx
+++ b/src/app/programas/page.tsx
@@ -1,0 +1,5 @@
+ import Programas from '@/features/programas/components/index';
+
+export default function ProgramasPage() {
+  return <Programas />;
+}

--- a/src/features/programas/components/BreadcrumbSection/BreadcrumbSection.module.css
+++ b/src/features/programas/components/BreadcrumbSection/BreadcrumbSection.module.css
@@ -1,0 +1,60 @@
+.breadcrumbSection {
+  margin-bottom: 1rem;
+  width: 100%;
+}
+
+.breadcrumbContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background-color: var(--color-gray-light, #f3f4f6);
+  border-radius: 8px;
+  border: 1px solid var(--color-border, #d1d5db);
+  width: 100%;
+  box-sizing: border-box;
+  max-width: 900px; /* MISMO ANCHO QUE EL GRID */
+  margin: 0 auto; /* Centrar */
+}
+
+.breadcrumbIcon {
+  font-size: 1.25rem;
+}
+
+.breadcrumbList {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.breadcrumbItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.separator {
+  color: var(--color-text-secondary, #6b7280);
+  font-weight: 600;
+}
+
+.breadcrumbLink,
+.breadcrumbText {
+  color: var(--color-text-primary, #374151);
+  text-decoration: none;
+  font-weight: 500;
+  transition: opacity 0.2s ease;
+}
+
+.breadcrumbLink:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
+.active {
+  font-weight: 600;
+  opacity: 1;
+}

--- a/src/features/programas/components/BreadcrumbSection/BreadcrumbSection.tsx
+++ b/src/features/programas/components/BreadcrumbSection/BreadcrumbSection.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React from 'react';
+import clsx from 'clsx';
+import styles from './BreadcrumbSection.module.css';
+import type { BreadcrumbItem } from '../../types';
+
+interface BreadcrumbSectionProps {
+  breadcrumbs?: BreadcrumbItem[];
+  className?: string;
+}
+
+const BreadcrumbSection: React.FC<BreadcrumbSectionProps> = ({
+  breadcrumbs = [],
+  className
+}) => {
+  if (breadcrumbs.length === 0) return null;
+
+  return (
+    <nav className={clsx(styles.breadcrumbSection, className)} aria-label="Breadcrumb">
+      <div className={styles.breadcrumbContainer}>
+        <span className={styles.breadcrumbIcon}>📚</span>
+        <ol className={styles.breadcrumbList}>
+          {breadcrumbs.map((item, index) => (
+            <li key={item.id} className={styles.breadcrumbItem}>
+              {index > 0 && (
+                <span className={styles.separator} aria-hidden="true">
+                  &gt;
+                </span>
+              )}
+              {item.href ? (
+                <a
+                  href={item.href}
+                  className={clsx(
+                    styles.breadcrumbLink,
+                    { [styles.active]: item.isActive }
+                  )}
+                >
+                  {item.label}
+                </a>
+              ) : (
+                <span
+                  className={clsx(
+                    styles.breadcrumbText,
+                    { [styles.active]: item.isActive }
+                  )}
+                >
+                  {item.label}
+                </span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </div>
+    </nav>
+  );
+};
+
+export default BreadcrumbSection;

--- a/src/features/programas/components/HeaderProgramSection/HeaderProgramSection.module.css
+++ b/src/features/programas/components/HeaderProgramSection/HeaderProgramSection.module.css
@@ -1,0 +1,18 @@
+.headerProgramSection {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-bg-secondary, #ffffff);
+  align-items: center; /* Centrar todo el contenido */
+}
+
+.headerArea {
+  background-color: transparent;
+  color: var(--color-text-primary, #374151);
+  padding: 2rem 2rem 0 2rem; /* Sin padding bottom */
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 900px; /* EXACTAMENTE igual que el grid */
+  width: 100%;
+  box-sizing: border-box;
+}

--- a/src/features/programas/components/HeaderProgramSection/HeaderProgramSection.tsx
+++ b/src/features/programas/components/HeaderProgramSection/HeaderProgramSection.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React from 'react';
+import clsx from 'clsx';
+import styles from './HeaderProgramSection.module.css';
+import BreadcrumbSection from '../BreadcrumbSection/BreadcrumbSection';
+import HeaderProgramTitle from '../HeaderProgramTitle/HeaderProgramTitle';
+import SubjectContainer from '../SubjectContainer/SubjectContainer';
+import type { BreadcrumbItem, Program } from '../../types';
+
+interface HeaderProgramSectionProps {
+  breadcrumbs?: BreadcrumbItem[];
+  title?: string;
+  programs?: Program[];
+  selectedProgram?: string | null;
+  onProgramSelect?: (programId: string) => void;
+  className?: string;
+}
+
+const HeaderProgramSection: React.FC<HeaderProgramSectionProps> = ({
+  breadcrumbs = [],
+  title = "Sinfonía de la lectoescritura",
+  programs = [],
+  selectedProgram,
+  onProgramSelect,
+  className
+}) => {
+  return (
+    <div className={clsx(styles.headerProgramSection, className)}>
+      <div className={styles.headerArea}>
+        <BreadcrumbSection breadcrumbs={breadcrumbs} />
+        <HeaderProgramTitle title={title} />
+      </div>
+      <SubjectContainer
+        programs={programs}
+        selectedProgram={selectedProgram}
+        onProgramSelect={onProgramSelect}
+      />
+    </div>
+  );
+};
+
+export default HeaderProgramSection;

--- a/src/features/programas/components/HeaderProgramTitle/HeaderProgramTitle.module.css
+++ b/src/features/programas/components/HeaderProgramTitle/HeaderProgramTitle.module.css
@@ -1,0 +1,35 @@
+.headerProgramTitle {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+
+.titleContainer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem 2rem;
+  background-color: var(--color-gray-dark, #4a5568);
+  border-radius: 12px;
+  width: 100%;
+  max-width: 900px; /* EXACTAMENTE igual que el grid */
+  justify-content: center;
+  box-sizing: border-box;
+  margin: 0 auto; /* Centrar */
+}
+
+.titleIcon {
+  font-size: 2.5rem;
+  opacity: 0.9;
+}
+
+.mainTitle {
+  font-size: 2rem;
+  font-weight: 700;
+  color: white;
+  margin: 0;
+  text-align: center;
+  line-height: 1.2;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}

--- a/src/features/programas/components/HeaderProgramTitle/HeaderProgramTitle.tsx
+++ b/src/features/programas/components/HeaderProgramTitle/HeaderProgramTitle.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React from 'react';
+import clsx from 'clsx';
+import styles from './HeaderProgramTitle.module.css';
+
+interface HeaderProgramTitleProps {
+  title?: string;
+  icon?: string;
+  className?: string;
+}
+
+const HeaderProgramTitle: React.FC<HeaderProgramTitleProps> = ({
+  title = "Sinfonía de la lectoescritura",
+  icon = "📚",
+  className
+}) => {
+  return (
+    <div className={clsx(styles.headerProgramTitle, className)}>
+      <div className={styles.titleContainer}>
+        <div className={styles.titleIcon} aria-hidden="true">
+          {icon}
+        </div>
+        <h1 className={styles.mainTitle}>{title}</h1>
+      </div>
+    </div>
+  );
+};
+
+export default HeaderProgramTitle;

--- a/src/features/programas/components/HeaderSubject/HeaderSubject.module.css
+++ b/src/features/programas/components/HeaderSubject/HeaderSubject.module.css
@@ -1,0 +1,73 @@
+.headerSubject {
+  background-color: var(--color-gray-light, #e8e6e0);
+  padding: 1rem;
+  border-right: 1px solid var(--color-border, #d1d1d1);
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background-color: transparent; /* Sin fondo rojo */
+  border-radius: 8px;
+  color: #000000; /* CAMBIO: Texto negro */
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+  color: #000000; /* CAMBIO: Texto negro */
+}
+
+/* MANTENER: Las secciones azules de las otras materias */
+.subjectsList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.subjectItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 0.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: center;
+}
+
+.subjectItem:hover {
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+.selected {
+  background-color: var(--color-primary-blue, #3b82f6);
+  color: white;
+}
+
+.subjectIcon {
+  font-size: 1.5rem;
+}
+
+.subjectName {
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+@media (max-width: 768px) {
+  .headerSubject {
+    width: 100%;
+    padding: 1rem;
+  }
+
+  .subjectsList {
+    flex-direction: row;
+    justify-content: space-around;
+  }
+}

--- a/src/features/programas/components/HeaderSubject/HeaderSubject.tsx
+++ b/src/features/programas/components/HeaderSubject/HeaderSubject.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useCallback } from 'react';
+import clsx from 'clsx';
+import styles from './HeaderSubject.module.css';
+import type { Subject } from '../../types';
+
+interface HeaderSubjectProps {
+  subjects?: Subject[];
+  selectedSubject?: string;
+  onSubjectChange?: (subjectId: string) => void;
+  className?: string;
+}
+
+const HeaderSubject: React.FC<HeaderSubjectProps> = ({
+  subjects = [],
+  selectedSubject,
+  onSubjectChange,
+  className
+}) => {
+  const handleSubjectClick = useCallback((subjectId: string) => {
+    onSubjectChange?.(subjectId);
+  }, [onSubjectChange]);
+
+  // FILTRAR: Eliminar SOLO el item "materias" (la sección azul con el libro)
+  const filteredSubjects = subjects.filter(subject => subject.id !== 'materias');
+
+  const renderSubjectItem = useCallback((subject: Subject) => {
+    const isSelected = selectedSubject === subject.id || subject.isSelected;
+
+    return (
+      <div
+        key={subject.id}
+        className={clsx(
+          styles.subjectItem,
+          { [styles.selected]: isSelected }
+        )}
+        onClick={() => handleSubjectClick(subject.id)}
+        role="button"
+        tabIndex={0}
+        aria-label={`Select ${subject.name}`}
+      >
+        <div className={styles.subjectIcon}>{subject.icon}</div>
+        <span className={styles.subjectName}>{subject.name}</span>
+      </div>
+    );
+  }, [selectedSubject, handleSubjectClick]);
+
+  return (
+    <aside className={clsx(styles.headerSubject, className)}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>Materias</h2>
+      </div>
+      
+      {/* MANTENER: Las otras secciones azules (Sinfonía, Matemáticas, Exploración) */}
+      <nav className={styles.subjectsList}>
+        {filteredSubjects.map(renderSubjectItem)}
+      </nav>
+    </aside>
+  );
+};
+
+export default HeaderSubject;

--- a/src/features/programas/components/ProgramCard/ProgramCard.module.css
+++ b/src/features/programas/components/ProgramCard/ProgramCard.module.css
@@ -1,0 +1,129 @@
+.programCard {
+  background: linear-gradient(
+    135deg,
+    var(--color-card-bg, #f8fafc) 0%,
+    var(--color-card-bg-end, #e2e8f0) 100%
+  );
+  border-radius: 16px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  min-height: 160px;
+  border: 2px solid var(--color-border-card, #cbd5e1);
+  position: relative;
+  overflow: hidden;
+}
+
+.programCard::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(59, 130, 246, 0.1) 0%,
+    rgba(147, 51, 234, 0.1) 100%
+  );
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.programCard:hover::before,
+.hovered::before {
+  opacity: 1;
+}
+
+.programCard:hover,
+.hovered {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+  border-color: var(--color-primary-blue, #3b82f6);
+}
+
+.inactive {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.inactive:hover {
+  transform: none;
+  box-shadow: none;
+  border-color: var(--color-border-card, #cbd5e1);
+}
+
+.cardContent {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+}
+
+.titleSection {
+  margin-bottom: 1rem;
+}
+
+.programTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #374151);
+  margin: 0 0 0.5rem 0;
+  line-height: 1.3;
+}
+
+.programSubtitle {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #6b7280);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.programDescription {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.programCard:focus {
+  outline: 3px solid var(--color-primary-blue, #3b82f6);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .programCard {
+    padding: 1.5rem;
+    min-height: 140px;
+  }
+
+  .programTitle {
+    font-size: 1rem;
+  }
+
+  .programSubtitle {
+    font-size: 0.875rem;
+  }
+
+  .programDescription {
+    font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .programCard {
+    padding: 1.25rem;
+    min-height: 120px;
+  }
+
+  .programTitle {
+    font-size: 0.9rem;
+  }
+
+  .programSubtitle {
+    font-size: 0.8rem;
+  }
+}

--- a/src/features/programas/components/ProgramCard/ProgramCard.tsx
+++ b/src/features/programas/components/ProgramCard/ProgramCard.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import clsx from 'clsx';
+import styles from './ProgramCard.module.css';
+import type { ProgramCardProps } from '../../types';
+
+const ProgramCard: React.FC<ProgramCardProps> = ({
+  program,
+  onClick,
+  className
+}) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleMouseEnter = useCallback(() => {
+    if (program.isActive) {
+      setIsHovered(true);
+    }
+  }, [program.isActive]);
+
+  const handleMouseLeave = useCallback(() => {
+    setIsHovered(false);
+  }, []);
+
+  const handleClick = useCallback(() => {
+    if (program.isActive) {
+      onClick?.(program.id);
+    }
+  }, [onClick, program.id, program.isActive]);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
+    if ((event.key === 'Enter' || event.key === ' ') && program.isActive) {
+      event.preventDefault();
+      handleClick();
+    }
+  }, [handleClick, program.isActive]);
+
+  return (
+    <div
+      className={clsx(
+        styles.programCard,
+        {
+          [styles.hovered]: isHovered,
+          [styles.inactive]: !program.isActive,
+        },
+        className
+      )}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={program.isActive ? 0 : -1}
+      aria-label={`${program.title} ${program.subtitle}`}
+      aria-disabled={!program.isActive}
+    >
+      <div className={styles.cardContent}>
+        <div className={styles.titleSection}>
+          <h3 className={styles.programTitle}>{program.title}</h3>
+          {program.subtitle && (
+            <p className={styles.programSubtitle}>{program.subtitle}</p>
+          )}
+        </div>
+        {program.description && (
+          <p className={styles.programDescription}>{program.description}</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProgramCard;

--- a/src/features/programas/components/SubjectContainer/SubjectContainer.module.css
+++ b/src/features/programas/components/SubjectContainer/SubjectContainer.module.css
@@ -1,0 +1,80 @@
+.subjectContainer {
+  flex: 1;
+  padding: 3rem 2rem;
+  background-color: var(--color-bg-secondary, #f8fafc);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.programsGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  gap: 2rem;
+  max-width: 900px; /* ANCHO DE REFERENCIA - DEBE SER IGUAL */
+  width: 100%;
+  min-height: 400px;
+}
+
+/* RESPONSIVE - Mantener alineación en todas las resoluciones */
+@media (max-width: 768px) {
+  .headerArea {
+    padding: 1.5rem 1rem 0 1rem;
+    max-width: 600px;
+  }
+  
+  .breadcrumbContainer {
+    max-width: 600px;
+    padding: 0.5rem 0.75rem;
+  }
+  
+  .titleContainer {
+    padding: 1rem 1.5rem;
+    max-width: 600px;
+  }
+  
+  .programsGrid {
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(3, 1fr);
+    gap: 1.5rem;
+    max-width: 600px;
+  }
+  
+  .mainTitle {
+    font-size: 1.5rem;
+  }
+  
+  .breadcrumbIcon {
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .headerArea {
+    max-width: 400px;
+    padding: 1rem 0.5rem 0 0.5rem;
+  }
+  
+  .breadcrumbContainer {
+    max-width: 400px;
+  }
+  
+  .titleContainer {
+    flex-direction: column;
+    gap: 0.5rem;
+    max-width: 400px;
+    padding: 1rem;
+  }
+  
+  .programsGrid {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(6, 1fr);
+    gap: 1rem;
+    max-width: 400px;
+  }
+  
+  .mainTitle {
+    font-size: 1.25rem;
+  }
+}

--- a/src/features/programas/components/SubjectContainer/SubjectContainer.tsx
+++ b/src/features/programas/components/SubjectContainer/SubjectContainer.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useCallback } from 'react';
+import clsx from 'clsx';
+import styles from './SubjectContainer.module.css';
+import ProgramCard from '../ProgramCard/ProgramCard';
+import type { Program } from '../../types';
+
+interface SubjectContainerProps {
+  programs?: Program[];
+  selectedProgram?: string | null;
+  onProgramSelect?: (programId: string) => void;
+  className?: string;
+}
+
+const SubjectContainer: React.FC<SubjectContainerProps> = ({
+  programs = [],
+  selectedProgram,
+  onProgramSelect,
+  className
+}) => {
+  const handleProgramClick = useCallback((programId: string) => {
+    onProgramSelect?.(programId);
+  }, [onProgramSelect]);
+
+  const renderProgramCards = useCallback(() => {
+    return programs.map((program) => (
+      <ProgramCard
+        key={program.id}
+        program={program}
+        onClick={handleProgramClick}
+        className={clsx({
+          [styles.selectedCard]: selectedProgram === program.id
+        })}
+      />
+    ));
+  }, [programs, selectedProgram, handleProgramClick]);
+
+  if (programs.length === 0) {
+    return (
+      <div className={clsx(styles.subjectContainer, className)}>
+        <div className={styles.emptyState}>
+          <div className={styles.emptyIcon}>📚</div>
+          <p className={styles.emptyText}>No programs available</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={clsx(styles.subjectContainer, className)}>
+      <div
+        className={styles.programsGrid}
+        role="grid"
+        aria-label="Program selection"
+      >
+        {renderProgramCards()}
+      </div>
+    </div>
+  );
+};
+
+export default SubjectContainer;

--- a/src/features/programas/components/UtilitySidebar/UtilitySidebar.module.css
+++ b/src/features/programas/components/UtilitySidebar/UtilitySidebar.module.css
@@ -1,0 +1,91 @@
+.utilitySidebar {
+  background-color: var(--color-gray-light, #e8e6e0);
+  padding: 1rem 0.5rem;
+  border-left: 1px solid var(--color-border, #d1d1d1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 80px;
+  min-height: 100vh;
+}
+
+.iconList {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  align-items: center;
+}
+
+.iconButton {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background-color: transparent;
+  border: 2px solid transparent;
+  position: relative;
+}
+
+.iconButton:hover {
+  background-color: rgba(255, 255, 255, 0.5);
+  transform: scale(1.05);
+}
+
+.iconButton:focus {
+  outline: none;
+  border-color: var(--color-primary-blue, #3b82f6);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.active {
+  background-color: var(--color-primary-blue, #3b82f6);
+  color: white;
+  transform: scale(1.1);
+  box-shadow: 0 4px 8px rgba(59, 130, 246, 0.3);
+}
+
+.active:hover {
+  background-color: var(--color-primary-blue-dark, #2563eb);
+  transform: scale(1.1);
+}
+
+.iconSymbol {
+  font-size: 1.5rem;
+  line-height: 1;
+  user-select: none;
+}
+
+.active .iconSymbol {
+  filter: brightness(1.2);
+}
+
+@media (max-width: 768px) {
+  .utilitySidebar {
+    width: 100%;
+    min-height: auto;
+    padding: 0.75rem;
+    border-left: none;
+    border-top: 1px solid var(--color-border, #d1d1d1);
+    order: 3;
+  }
+
+  .iconList {
+    flex-direction: row;
+    justify-content: space-around;
+    gap: 0.5rem;
+  }
+
+  .iconButton {
+    width: 40px;
+    height: 40px;
+  }
+
+  .iconSymbol {
+    font-size: 1.25rem;
+  }
+}

--- a/src/features/programas/components/UtilitySidebar/UtilitySidebar.tsx
+++ b/src/features/programas/components/UtilitySidebar/UtilitySidebar.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import clsx from 'clsx';
+import styles from './UtilitySidebar.module.css';
+
+interface UtilityIcon {
+  id: string;
+  icon: string;
+  label: string;
+  isActive?: boolean;
+  onClick?: () => void;
+}
+
+interface UtilitySidebarProps {
+  className?: string;
+  onIconClick?: (iconId: string) => void;
+}
+
+const defaultIcons: UtilityIcon[] = [
+  { id: 'profile', icon: '👧', label: 'Perfil' },
+  { id: 'books', icon: '📚', label: 'Libros' },
+  { id: 'calendar', icon: '📅', label: 'Calendario' },
+  { id: 'brain', icon: '🧠', label: 'Actividades' },
+  { id: 'diamond', icon: '💎', label: 'Logros' },
+  { id: 'exit', icon: '↗️', label: 'Salir' },
+];
+
+const UtilitySidebar: React.FC<UtilitySidebarProps> = ({
+  className,
+  onIconClick
+}) => {
+  const [activeIcon, setActiveIcon] = useState<string | null>(null);
+
+  const handleIconClick = useCallback((iconId: string) => {
+    setActiveIcon(iconId);
+    onIconClick?.(iconId);
+    console.log('Utility icon clicked:', iconId);
+  }, [onIconClick]);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent, iconId: string) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleIconClick(iconId);
+    }
+  }, [handleIconClick]);
+
+  const renderIcon = useCallback((utilityIcon: UtilityIcon) => {
+    const isActive = activeIcon === utilityIcon.id || utilityIcon.isActive;
+
+    return (
+      <div
+        key={utilityIcon.id}
+        className={clsx(
+          styles.iconButton,
+          { [styles.active]: isActive }
+        )}
+        onClick={() => handleIconClick(utilityIcon.id)}
+        onKeyDown={(e) => handleKeyDown(e, utilityIcon.id)}
+        role="button"
+        tabIndex={0}
+        aria-label={utilityIcon.label}
+        title={utilityIcon.label}
+      >
+        <span className={styles.iconSymbol} aria-hidden="true">
+          {utilityIcon.icon}
+        </span>
+      </div>
+    );
+  }, [activeIcon, handleIconClick, handleKeyDown]);
+
+  return (
+    <aside className={clsx(styles.utilitySidebar, className)}>
+      <nav className={styles.iconList} aria-label="Utility navigation">
+        {defaultIcons.map(renderIcon)}
+      </nav>
+    </aside>
+  );
+};
+
+export default UtilitySidebar;

--- a/src/features/programas/components/index/index.module.css
+++ b/src/features/programas/components/index/index.module.css
@@ -1,0 +1,14 @@
+.programas {
+  display: grid;
+  grid-template-columns: 200px 1fr 80px;
+  height: 100vh;
+  background-color: var(--color-bg-primary, #f5f5f0);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+@media (max-width: 768px) {
+  .programas {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+  }
+}

--- a/src/features/programas/components/index/index.tsx
+++ b/src/features/programas/components/index/index.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import clsx from 'clsx';
+import styles from './index.module.css';
+import HeaderSubject from '../HeaderSubject/HeaderSubject';
+import HeaderProgramSection from '../HeaderProgramSection/HeaderProgramSection';
+import UtilitySidebar from '../UtilitySidebar/UtilitySidebar';
+import type { Program, Subject, BreadcrumbItem } from '../../types';
+
+interface ProgramasProps {
+  className?: string;
+}
+
+const subjects: Subject[] = [
+  { id: 'materias', name: 'Materias', icon: '📚' },
+  { id: 'sinfonia', name: 'Sinfonía de la Lectoescritura', icon: '🎵', isSelected: true },
+  { id: 'matematicas', name: 'Matemáticas', icon: '🔢' },
+  { id: 'exploracion', name: 'Exploración del Mundo', icon: '🌍' },
+];
+
+const programs: Program[] = [
+  { id: 'preludio', title: 'Preludio:', subtitle: 'Melodía del Sonido', isActive: true, order: 0 },
+  { id: 'movimiento1', title: 'Movimiento I:', subtitle: 'Notas de la palabra', isActive: true, order: 1 },
+  { id: 'movimiento2', title: 'Movimiento II:', subtitle: 'El compás de la oración', isActive: true, order: 2 },
+  { id: 'movimiento3', title: 'Movimiento III:', subtitle: 'Ritmo y Trazo', isActive: true, order: 3 },
+  { id: 'movimiento4', title: 'Movimiento IV:', subtitle: 'Sinfónica del Pensamiento', isActive: true, order: 4 },
+  { id: 'movimiento5', title: 'Movimiento V:', subtitle: 'Entre Líneas', isActive: true, order: 5 },
+];
+
+const breadcrumbs: BreadcrumbItem[] = [
+  { id: 'sinfonia', label: 'Sinfonía', href: '/materias' },
+  { id: 'programas', label: 'Programas', isActive: true },
+];
+
+const Programas: React.FC<ProgramasProps> = ({ className }) => {
+  const [selectedSubject, setSelectedSubject] = useState<string>('sinfonia');
+  const [selectedProgram, setSelectedProgram] = useState<string | null>(null);
+
+  const handleSubjectChange = useCallback((subjectId: string) => {
+    setSelectedSubject(subjectId);
+  }, []);
+
+  const handleProgramSelect = useCallback((programId: string) => {
+    setSelectedProgram(programId);
+    console.log('Selected program:', programId);
+  }, []);
+
+  return (
+    <div className={clsx(styles.programas, className)}>
+      <HeaderSubject
+        subjects={subjects}
+        selectedSubject={selectedSubject}
+        onSubjectChange={handleSubjectChange}
+      />
+      <HeaderProgramSection
+        breadcrumbs={breadcrumbs}
+        title="Sinfonía de la lectoescritura"
+        programs={programs}
+        selectedProgram={selectedProgram}
+        onProgramSelect={handleProgramSelect}
+      />
+      <UtilitySidebar />
+    </div>
+  );
+};
+
+export default Programas;

--- a/src/features/programas/types/index.ts
+++ b/src/features/programas/types/index.ts
@@ -1,0 +1,50 @@
+export interface Program {
+  id: string;
+  title: string;
+  subtitle?: string;
+  description?: string;
+  isActive?: boolean;
+  order?: number;
+}
+
+export interface Subject {
+  id: string;
+  name: string;
+  icon: string;
+  isSelected?: boolean;
+}
+
+export interface BreadcrumbItem {
+  id: string;
+  label: string;
+  href?: string;
+  isActive?: boolean;
+}
+
+export interface ProgramasProps {
+  className?: string;
+  subjectId?: string;
+  onProgramSelect?: (programId: string) => void;
+}
+
+export interface ProgramCardProps {
+  program: Program;
+  onClick?: (programId: string) => void;
+  className?: string;
+}
+
+export interface HeaderSubjectProps {
+  subjects?: Subject[];
+  selectedSubject?: string;
+  onSubjectChange?: (subjectId: string) => void;
+  className?: string;
+}
+
+export interface HeaderProgramSectionProps {
+  breadcrumbs?: BreadcrumbItem[];
+  title?: string;
+  programs?: Program[];
+  selectedProgram?: string | null;
+  onProgramSelect?: (programId: string) => void;
+  className?: string;
+}


### PR DESCRIPTION
## 📚 Overview
Implements a complete Programas page following the established modular architecture pattern used in the Materias page. This page displays educational programs in a 3x2 grid layout with proper navigation and responsive design.

## ✨ Features Added
- **Modular component architecture** following project patterns
- **HeaderSubject sidebar** with subject navigation (removed specific blue Materias section)
- **Breadcrumb navigation** with "Sinfonía > Programas" format
- **Program grid layout** displaying 6 movement programs in 3x2 format
- **Responsive design** for desktop, tablet, and mobile devices
- **Interactive elements** with hover effects and keyboard navigation
- **UtilitySidebar** with navigation icons